### PR TITLE
Fix ImportError when importing jsonlogger

### DIFF
--- a/scrapekit/logs.py
+++ b/scrapekit/logs.py
@@ -1,7 +1,11 @@
 import os
 import logging
 
-import jsonlogger
+try:
+    import jsonlogger
+except ImportError:
+    # python-json-logger version 0.1.0 has changed the import structure
+    from pythonjsonlogger import jsonlogger
 
 
 class TaskAdapter(logging.LoggerAdapter):


### PR DESCRIPTION
Hi, the scraper raises error since `jsonlogger` isn't importable.

``` pytb
Traceback (most recent call last):
  File "test.py", line 1, in <module>
    from scrapekit import Scraper
  File "/opt/contrib/scrapekit/scrapekit/__init__.py", line 1, in <module>
    from scrapekit.core import Scraper
  File "/opt/contrib/scrapekit/scrapekit/core.py", line 10, in <module>
    from scrapekit.logs import make_logger
  File "/opt/contrib/scrapekit/scrapekit/logs.py", line 5, in <module>
    import jsonlogger
ImportError: No module named jsonlogger
```

According to [python-json-logger](https://github.com/madzak/python-json-logger#usage) documentation, version 0.1.0 has changed the import structure:

> Please note: version 0.1.0 has changed the import structure, please update to the following example for proper importing

This PR tries to conform to `jsonlogger` changes mentioned above.
