### PR TITLE
Storage layer

### DIFF
--- a/scrapekit/config.py
+++ b/scrapekit/config.py
@@ -17,11 +17,11 @@ class Config(object):
             self.config.update(config)
 
     def _get_defaults(self):
-        #name = self.scraper.name
+        name = self.scraper.name
         return {
             'cache_policy': 'http',
             'threads': multiprocessing.cpu_count() * 2,
-            'data_path': os.path.join(os.getcwd(), 'data'),
+            'data_path': os.path.join(os.getcwd(), 'data', name),
             'reports_path': None
         }
 

--- a/scrapekit/core.py
+++ b/scrapekit/core.py
@@ -84,7 +84,7 @@ class Scraper(object):
         """ Generate a static HTML report for the last runs of the
         scraper from its log file. """
         index_file = reporting.generate(self)
-        print "Report available at: %s" % index_file
+        print("Report available at: file://%s" % index_file)
 
     def __repr__(self):
         return '<Scraper(%s)>' % self.name

--- a/scrapekit/core.py
+++ b/scrapekit/core.py
@@ -27,6 +27,8 @@ class Scraper(object):
         self._task_manager = None
         self.task_ctx = local()
         self.log = make_logger(self)
+
+        self.session = self.Session()
         if report:
             atexit.register(self.report)
 

--- a/scrapekit/core.py
+++ b/scrapekit/core.py
@@ -15,7 +15,7 @@ class Scraper(object):
     """ Scraper application object which handles resource management
     for a variety of related functions. """
 
-    def __init__(self, name, config=None, report=True):
+    def __init__(self, name, config=None, report=False):
         self.name = name
         self.id = uuid4()
         self.start_time = datetime.utcnow()

--- a/scrapekit/tasks.py
+++ b/scrapekit/tasks.py
@@ -103,9 +103,10 @@ class Task(object):
     `pipe` and `run`).
     """
 
-    def __init__(self, scraper, fn):
+    def __init__(self, scraper, fn, task_id=None):
         self.scraper = scraper
         self.fn = fn
+        self.task_id = task_id
         self._listeners = []
         self._source = None
 
@@ -115,7 +116,7 @@ class Task(object):
         pipeline listeners that have been associated with this task.
         """
         self.scraper.task_ctx.name = self.fn.func_name
-        self.scraper.task_ctx.id = uuid4()
+        self.scraper.task_ctx.id = self.task_id or uuid4()
 
         try:
             self.scraper.log.debug('Begin task', extra={

--- a/scrapekit/tasks.py
+++ b/scrapekit/tasks.py
@@ -60,6 +60,8 @@ class TaskManager(object):
 
         Do not call this directly, use Task.queue/Task.run instead.
         """
+        if self.num_threads == 0:
+            return task(*args, **kwargs)
         if self.queue is None:
             self._spawn()
         self.queue.put((task, args, kwargs))


### PR DESCRIPTION
This PR contains a few things:
- some convenience fixes/features (also present as separate PR #5, will rebase this branch when merged)
- a sqlite database for tasks and results
- a way of storing scrape tasks in the db and running them
- a way of marking tasks as done and storing results of tasks

This is how I run scrapers:

``` python
scraper = Scraper('scraper_name', {'threads': 8})
scraper.log.info('Store Tasks')
scraper.store_tasks('scrape_detail', get_tasks()) # get_tasks is a generator for args, kwargs
scraper.log.info('Process tasks')
scraper.process_tasks() # Runs all stored tasks that are not done
```

Scrapers can store results like this:

```
# Do some scraping
self.write_result(data_dict, ['unique_field'])
```

What this still needs:
- [ ] A way to chunk/stream tasks from the db to the threads without locking the db, currently requires all tasks to be in memory before processing them
- [ ] More expressive marking of task state in database (failed)
- [ ] Clearing tasks from the database
- [ ] Documentation
- [ ] Make pipelines work with this flow
- [ ] Clean up, better API
- [ ] Better namespacing on scraper object?

Nice to have:
- [ ] Some kind of auto-cli for the scraper which accepts configuration and commands to run scrapers, clear tasks
- [ ] A way to configure the database?
- [ ] Reporting from the database to nice HTML?
